### PR TITLE
fix: pr template comment location

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,11 @@
+
+Checklist:
+
+* [ ] I have updated the necessary documentation
+* [ ] I have updated the changelog, if necessary (CHANGELOG.md)
+* [ ] I have signed off all my commits as required by [DCO](../CONTRIBUTING.md#legal)
+* [ ] My build is green
+
 <!--
 Note on DCO:
 
@@ -7,10 +15,3 @@ Note on Versioning:
 
 Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
 -->
-
-Checklist:
-
-* [ ] I have updated the necessary documentation
-* [ ] I have updated the changelog, if necessary (CHANGELOG.md)
-* [ ] I have signed off all my commits as required by [DCO](../CONTRIBUTING.md#legal)
-* [ ] My build is green


### PR DESCRIPTION
move comment under checklist so users don't need to copy/paste their first git commit message under the comment

Checklist:

* [ ] I have updated the necessary documentation
* [ ] I have updated the changelog, if necessary (CHANGELOG.md)
* [x] I have signed off all my commits as required by [DCO](../CONTRIBUTING.md#legal)
* [ ] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->